### PR TITLE
Re-license to 2-clause BSD type license

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,15 +1,32 @@
 
 HISTORY.txt -- libdasm release history
-(c) 2004 - 2007 jt / nologin.org
-    2009 - 2010 Ange Albertini
+Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>)
+Copyright (c) 2005       Ero Carrera Ventura <ero / dkbza.org> (Python binding)
+Copyright (c) 2006       Matt Miller skape <mmiller / hick.org> (Ruby binding)
+Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
+Copyright (c) 2015-2018  Joshua Pereyda <jtpereyda / github.com>
 ======================================
 
-1.6 r14
-+ eflags are now accessible from python [nnp]
-+ added group 2 (c0-c1) SAL (xx110xxx) [Silvio Cesare]
-+ added 0xf6-0xf7 (group 3) test xx001xxx
-+ added 0d9 d0-ff fpu [Georg 'oxff' Wicherski]
-* fixed operand types for mov segment register (8c) and movzx (0fb6 and 0fb7) [Silvio Cesare]
+
+1.6 r16
+- pydasm/setup.py Switching to setuptools
+- re-license to 2-clause BSD
+- available from:
+  https://github.com/jtpereyda/libdasm
+
+1.6 r15
+1.6 r14 - 2009-2010
+
+- eflags are now accessible from python [nnp]
+- added group 2 (c0-c1) SAL (xx110xxx) [Silvio Cesare]
+- added 0xf6-0xf7 (group 3) test xx001xxx
+- added 0d9 d0-ff fpu [Georg 'oxff' Wicherski]
+- fixed operand types for mov segment register (8c) and movzx (0fb6 and 0fb7) [Silvio Cesare]
+- partially re-licensed to BSD 3-clause style license. New BSD license was advertised on project site,
+  but was not progressed to the code.
+- available from:
+  https://code.google.com/archive/p/libdasm/
+  https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libdasm/libdasm-beta.zip
 
 1.5 12/27/2006
 
@@ -20,17 +37,27 @@ HISTORY.txt -- libdasm release history
 - New attributes in instructions structure:
   eflags_affected and eflags_used. Defines if instruction affects
   cpu eflags (thanks skape!).
+- available from:
+  http://www.klake.org/~jt/misc/libdasm-1.5.tar.gz
+  https://web.archive.org/web/20120119123445/http://www.klake.org/~jt/misc/libdasm-1.5.tar.gz
+  https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/libdasm/libdasm-1.5.tar.gz
 
 1.4 01/06/2006
 
 - Fixed jecxz/jcxz bug
 - Fixed push/pop operand size issues
 - Typo: punockldq -> punpckldq
+- available from:
+  http://www.klake.org/~jt/misc/libdasm-1.4.tar.gz
+  https://web.archive.org/web/20060718012748/http://www.klake.org/~jt/misc/libdasm-1.4.tar.gz
 
 1.3.1 10/03/2005
 
 - Fixed a bug with word displacement addressing.
   (thanks Arnaud Pilon)
+- available from:
+  http://www.klake.org/~jt/misc/libdasm-1.3.1.tar.gz
+  https://web.archive.org/web/20060105052847/http://www.klake.org/~jt/misc/libdasm-1.3.1.tar.gz
 
 1.3 10/01/2005
 
@@ -139,6 +166,8 @@ HISTORY.txt -- libdasm release history
  - Fixed addressing mode of opcode 0x8d (E -> M)
  - Changed das.c to do some buffer sanity checking
  - Created simple.c
+ - available from:
+   http://www.klake.org/~jt/misc/libdasm-0.9.tar.gz
 
 0.6  12/06/2004
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>)
+Copyright (c) 2005       Ero Carrera Ventura <ero / dkbza.org> (Python binding)
+Copyright (c) 2006       Matt Miller skape <mmiller / hick.org> (Ruby binding)
+Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
+Copyright (c) 2015-2018  Joshua Pereyda <jtpereyda / github.com>
+
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1) Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+2) Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.txt
+++ b/README.txt
@@ -1,15 +1,21 @@
 
 libdasm -- simple x86 disassembly library
 =========================================
-(c) 2004 - 2006  jt / nologin.org 
+Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>)
+Copyright (c) 2005       Ero Carrera Ventura <ero / dkbza.org> (Python binding)
+Copyright (c) 2006       Matt Miller skape <mmiller / hick.org> (Ruby binding)
+Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
+Copyright (c) 2015-2018  Joshua Pereyda <jtpereyda / github.com>
 
 
-1. Acknowledgements
+1. Acknowledgments
 ===================
 
-Thanks to skape, thief, spoonm and fine folks @nologin for bug
-reports, ideas and support. Special thanks to ero for creating
-and contributing pydasm and to skape for rbdasm.
+Thanks to skape, thief, spoonm, Silvio Cesare, Georg oxff Wicherski, BeatriX
+and fine folks @nologin for bug reports, ideas and support.
+Special thanks to ero for creating and contributing pydasm
+and to skape for rbdasm.
+
 
 
 2. What is libdasm?
@@ -66,7 +72,7 @@ int get_instruction(
       enum Mode mode          // mode: MODE_32 or MODE_16
 );
 
-First argument is a refence to INSTRUCTION structure. There is no
+First argument is a reference to INSTRUCTION structure. There is no
 need to initialize the structure prior to function call, get_instruction
 will take care of filling it.
 
@@ -86,7 +92,7 @@ is zero, it indicates illegal instruction.
 When get_instruction returns, you can print the instruction with
 get_instruction_string or do analysis of the instruction members. When
 ready, increment data buffer pointer to next instruction and call
-get_instruction again. Here is pseudocode presenting this procedure:
+get_instruction again. Here is pseudo-code presenting this procedure:
 
 	INSTRUCTION inst;
 	int len, buflen, c = 0;
@@ -318,7 +324,7 @@ too complex..).
 
 5.2. Segment prefix formatting
 
-Libdasm is modelled after the assumption that there is only one memory
+Libdasm is modeled after the assumption that there is only one memory
 operand at maximum in the instruction. If there is segment register override,
 the segment register is placed in front of the memory operand, like this:
 
@@ -338,7 +344,7 @@ is equivalent to:
 
   cmpsd fs:[esi], es:[edi]
 
-And btw, if you are wondering what are those weird "(bt)" and "(bnt)"
+And BTW, if you are wondering what are those weird "(bt)" and "(bnt)"
 prefixes in front of conditional jumps, they are branch hint prefixes 
 ("branch taken" and "branch not taken").
 
@@ -357,7 +363,7 @@ Libdasm will not check for read buffer boundaries. It means that if the
 opcode requires additional data to be read and that data cannot be accessed,
 libdasm might access violate, depending on the implementation. There is no
 platform-independent way of checking this condition, so you better make
-sure of it by youself. If the data is real machine code, there is no
+sure of it by yourself. If the data is real machine code, there is no
 problem (unless of course there is a bug in libdasm) because libdasm needs
 to read exactly what the instruction requires and of course the full
 instruction is in buffer, right? But in some rare cases when disassembling
@@ -365,7 +371,7 @@ random data this could cause some troubles.
 
 5.5. Endianness
 
-Endianess might not be identified correctly on all platforms
+Endianness might not be identified correctly on all platforms
 (see libdasm.h for definition of __LITTLE_ENDIAN__). If you encounter
 endianness related problems, please report the system and possible workaround
 for the problem.
@@ -374,7 +380,7 @@ for the problem.
 5.6. Inline functions
 
 Some functions are defined as inline, this might not work for all compilers.
-Only gcc and msvc are tested by the author.
+Only gcc and MSVC are tested by the author.
 
 
 5.7. Other issues
@@ -386,19 +392,17 @@ Some known issues are listed in file TODO.txt.
 6. Licensing
 ============
 
-libdasm is public domain software. You can do whatever you like with it.
+libdasm was originally released as public domain software. You can do whatever you like with it.
+Due to some legal uncertainty of "public domain" in some countries it was re-licensed to
+2-clause BSD type license to allow both commercial and non-commercial use.
 
 
 7. How to contact the author
 ============================
 
 If you have bug report or some improvement ideas or want to harass the author
-for some other reason, you can try to send email to
-
-  jt[at]klake.org
-
-If you have questions about pydasm and rbdasm, check out directories
-"pydasm" and "rbdasm" for contact information.
+for some other reason, please raise the issue on GitHub:
+https://github.com/jtpereyda/libdasm/issues
 
 
 

--- a/examples/das.c
+++ b/examples/das.c
@@ -1,7 +1,28 @@
 
 /*
  * das.c -- simple 32-bit example disassembler program
- * (c) 2004 - 2005  jt / nologin.org
+ * Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * How to compile in MSVC environment:
  *   cl das.c ../libdasm.c

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -1,9 +1,31 @@
+
 /*
  * simple.c -- very simple 32-bit example disassembler program
- * (c) 2004  jt / nologin.org
+ * Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * How to compile in MSVC environment:
- *   cl das.c ../libdasm.c
+ *   cl simple.c ../libdasm.c
  *
  * In Unix environment, use the supplied Makefile
  *

--- a/libdasm.c
+++ b/libdasm.c
@@ -1,7 +1,29 @@
 
 /*
  * libdasm -- simple x86 disassembly library
- * (c) 2004 - 2006  jt / nologin.org
+ * Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+ * Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * libdasm.c:
  * This file contains most code of libdasm. Check out

--- a/libdasm.h
+++ b/libdasm.h
@@ -1,7 +1,29 @@
 
 /*
  * libdasm -- simple x86 disassembly library
- * (c) 2004 - 2006  jt / nologin.org
+ * Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+ * Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * libdasm.h:
  * Definitions for structures, functions and other weird stuff

--- a/opcode_tables.h
+++ b/opcode_tables.h
@@ -1,6 +1,29 @@
+
 /*
  * libdasm -- simple x86 disassembly library
- * (c) 2004 - 2006  jt / nologin.org
+ * Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+ * Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * opcode_tables.h:
  * Opcode tables for FPU, 1, 2 and 3-byte opcodes and

--- a/pydasm/das.py
+++ b/pydasm/das.py
@@ -1,8 +1,31 @@
 
 #
 # das.py -- simple 32-bit example disassembler program
-# (c) 2004  jt / nologin.org
-# (c) 2005  ero / dkbza.org (Python adaptation)
+# Copyright (c) 2005       Ero Carrera Ventura <ero / dkbza.org> (Python adaptation)
+# Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+# Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1) Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 #
 
 import os

--- a/pydasm/pydasm.c
+++ b/pydasm/pydasm.c
@@ -1,9 +1,32 @@
 
 /*
  * pydasm -- Python module wrapping libdasm
- * (c) 2005 ero / dkbza.org
+ * Copyright (c) 2005       Ero Carrera Ventura <ero / dkbza.org> (Python adaptation)
+ * Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+ * Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
  *
-*/
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
 
 #include <Python.h>

--- a/pydasm/setup.py
+++ b/pydasm/setup.py
@@ -1,3 +1,29 @@
+#
+# Copyright (c) 2005       Ero Carrera Ventura <ero / dkbza.org> (Python adaptation)
+# Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+# Copyright (c) 2009-2010  Ange Albertini <angea / github.com>
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1) Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
 
 import os
 from setuptools import setup, Extension

--- a/rbdasm/dasm.c
+++ b/rbdasm/dasm.c
@@ -1,23 +1,47 @@
-//
-// Wraps jt's libdasm in ruby classes that can be accessed through:
-//
-// Dasm
-// Dasm::Instruction
-// Dasm::Operand
-//
-// Example:
-//
-// dasm = Dasm.new
-//
-// dasm.disassemble(buf).each { |instruction|
-// 	puts instruction.to_s
-// }
-//
-// All credits for the disassembler go to jt <jt at klake.org> :)
-//
-// skape
-// 01/2006
-//
+
+/*
+ * Copyright (c) 2006       Matt Miller skape <mmiller / hick.org>
+ * Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Wraps jt's libdasm in ruby classes that can be accessed through:
+ *
+ * Dasm
+ * Dasm::Instruction
+ * Dasm::Operand
+ *
+ * Example:
+ *
+ * dasm = Dasm.new
+ *
+ * dasm.disassemble(buf).each { |instruction|
+ * 	puts instruction.to_s
+ * }
+ *
+ * All credits for the disassembler go to jt <jt at klake.org> :)
+ *
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <ruby.h>

--- a/rbdasm/dasm.rb.ut.rb
+++ b/rbdasm/dasm.rb.ut.rb
@@ -1,4 +1,27 @@
 #!/usr/bin/env ruby
+# Copyright (c) 2006       Matt Miller skape <mmiller / hick.org>
+# Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1) Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 $:.unshift(File.join(File.dirname(__FILE__)))
 
@@ -52,7 +75,7 @@ class Dasm::UnitTest < Test::Unit::TestCase
 		ary = d.disassemble(b1)
 
 		assert_not_nil(ary)
-		
+
 		inst1 = ary[0]
 		inst2 = ary[1]
 

--- a/rbdasm/extconf.rb
+++ b/rbdasm/extconf.rb
@@ -1,2 +1,26 @@
+# Copyright (c) 2006       Matt Miller skape <mmiller / hick.org>
+# Copyright (c) 2004-2007  Jarkko Turkulainen <jt / nologin.org> <turkja / github.com>
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1) Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 require 'mkmf'
 create_makefile('dasm')


### PR DESCRIPTION
Re-license to 2-clause BSD type license to finalize the transition
already started by Ange Albertini and to clear the legal ucertainty
of the "public domain" claim in the readme.