### PR TITLE
Adding DESTDIR variable to makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,25 +6,35 @@
 CC     = gcc
 CFLAGS = -Wall -O3 -fPIC
 PREFIX = /usr/local
+LIBDIR = $(PREFIX)/lib
+INCDIR = $(PREFIX)/include
+DESTDIR = /
 
 
 all: libdasm.o
-	$(CC) $(CFLAGS) -shared -o libdasm.so libdasm.c
+	$(CC) $(CFLAGS) -shared -fPIC -Wl,-soname,libdasm.so.1 -o libdasm.so libdasm.c
 	ar rc libdasm.a libdasm.o && ranlib libdasm.a
-	cd examples && make
+	make -C examples
+	make -C pydasm
 
 install:
-	cp libdasm.h  $(PREFIX)/include/
-	cp libdasm.a  $(PREFIX)/lib/
-	cp libdasm.so $(PREFIX)/lib/
-	cp libdasm.so $(PREFIX)/lib/libdasm.so.1.0
+	install -p -D libdasm.so $(DESTDIR)$(LIBDIR)/libdasm.so.1.0
+	ln -s "libdasm.so.1.0"   $(DESTDIR)$(LIBDIR)/libdasm.so.1
+	ln -s "libdasm.so.1.0"   $(DESTDIR)$(LIBDIR)/libdasm.so
+	install -d $(DESTDIR)$(INCDIR)
+	install -m 644 -p libdasm.h     $(DESTDIR)$(INCDIR)/libdasm.h
+	install -m 644 -p -D libdasm.a  $(DESTDIR)$(LIBDIR)/libdasm.a
+	make -C examples install DESTDIR=$(DESTDIR)
+	make -C pydasm   install DESTDIR=$(DESTDIR)
 
 uninstall:
-	rm -f $(PREFIX)/include/libdasm.h
-	rm -f $(PREFIX)/lib/libdasm.a
-	rm -f $(PREFIX)/lib/libdasm.so.1.0 $(PREFIX)/lib/libdasm.so
+	rm -f $(DESTDIR)$(INCDIR)/libdasm.h
+	rm -f $(DESTDIR)$(LIBDIR)/libdasm.a
+	rm -f $(DESTDIR)$(LIBDIR)/libdasm.so.1.0 $(DESTDIR)$(LIBDIR)/libdasm.so
 
 clean:
 	rm -f libdasm.o libdasm.so libdasm.a
-	cd examples && make clean
+	make -C examples clean
+	make -C pydasm clean
+
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -6,13 +6,16 @@
 
 CC      = gcc
 CFLAGS  = -Wall -O3
+BINDIR  = /usr/local/bin
 
 all: das simple 
 
 das: das.o
-	$(CC) $(CFLAGS) -o das das.o ../libdasm.a
+	$(CC) $(CFLAGS) -o das das.o -l dasm -L ../
 simple: simple.o
-	$(CC) $(CFLAGS) -o simple simple.o ../libdasm.a
+	$(CC) $(CFLAGS) -o simple simple.o -l dasm -L ../
+install: das
+	install -p -D das $(DESTDIR)$(BINDIR)/das
 clean:
 	rm -f das simple *.o
 

--- a/pydasm/Makefile
+++ b/pydasm/Makefile
@@ -1,0 +1,9 @@
+DESTDIR=/
+BINDIR=/usr/local/bin
+
+all:
+	python setup.py build
+
+install:
+	python setup.py install --skip-build --root $(DESTDIR)
+	install -m 755 -p -D das.py $(DESTDIR)$(BINDIR)/das.py

--- a/pydasm/das.py
+++ b/pydasm/das.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env python
 #
 # das.py -- simple 32-bit example disassembler program
 # Copyright (c) 2005       Ero Carrera Ventura <ero / dkbza.org> (Python adaptation)


### PR DESCRIPTION
This patch is adding DESTDIR variable to the makefiles.
It would make packaging of the libdasm easier. It allows to install
to specified directory instead of the system directories.