### PR TITLE
do not ask for unnecessary write rights

### DIFF
--- a/examples/das.c
+++ b/examples/das.c
@@ -156,7 +156,7 @@ unsigned char * read_file(int *len, char *name) {
         int             c;
         struct stat     sstat;
 
-        if ((fp = fopen(name, "r+b")) == NULL) {
+        if ((fp = fopen(name, "rb")) == NULL) {
                 fprintf(stderr,"Error: unable to open file \"%s\"\n", name);
                 exit(0);
         }


### PR DESCRIPTION
The example das utility is asking (probably by typo) for write access when it is not needed.
This will change it to request only read-only rights to read binary file.
